### PR TITLE
deps: bump go-calcmark to v2.0.0-rc.1 (Period type system)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,12 @@ module github.com/CalcMark/calcmark-lark
 
 go 1.25.1
 
+// Local trial against the v2.0 Period type system on
+// upstream go-calcmark feat/period-type-system-v2 (PR #145).
+// Remove this replace and bump to the released v2.0.0 once the
+// upstream PR merges and tags.
+replace github.com/CalcMark/go-calcmark => /Users/bitsbyme/projects/cm/go-calcmark
+
 require (
 	github.com/CalcMark/go-calcmark v1.12.1
 	golang.org/x/time v0.15.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/CalcMark/calcmark-lark
 go 1.25.1
 
 require (
-	github.com/CalcMark/go-calcmark/v2 v2.0.0-rc.1
+	github.com/CalcMark/go-calcmark/v2 v2.0.0
 	golang.org/x/time v0.15.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,8 @@ module github.com/CalcMark/calcmark-lark
 
 go 1.25.1
 
-// Local trial against the v2.0 Period type system on
-// upstream go-calcmark feat/period-type-system-v2 (PR #145).
-// Remove this replace and bump to the released v2.0.0 once the
-// upstream PR merges and tags.
-replace github.com/CalcMark/go-calcmark => /Users/bitsbyme/projects/cm/go-calcmark
-
 require (
-	github.com/CalcMark/go-calcmark v1.12.1
+	github.com/CalcMark/go-calcmark/v2 v2.0.0-rc.1
 	golang.org/x/time v0.15.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/CalcMark/go-calcmark/v2 v2.0.0-rc.1 h1:/nNX3KBx9h49D2IHlur+EdE/8X645GO4PScLcRsx/ho=
+github.com/CalcMark/go-calcmark/v2 v2.0.0-rc.1/go.mod h1:phmoVSpMuYvPsW8eAiPLRHdBjTt6hqbVU7I1sacEv/s=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/CalcMark/go-calcmark v1.12.1 h1:3UsFJBPdyDv4e5ba+ax1pjBViRCZvrzyqUqi1EetN6Q=
-github.com/CalcMark/go-calcmark v1.12.1/go.mod h1:GLWExDVP6nHWBQoVszzmh8E2nWFUigUTyrHL+fY914A=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/CalcMark/go-calcmark/v2 v2.0.0-rc.1 h1:/nNX3KBx9h49D2IHlur+EdE/8X645GO4PScLcRsx/ho=
-github.com/CalcMark/go-calcmark/v2 v2.0.0-rc.1/go.mod h1:phmoVSpMuYvPsW8eAiPLRHdBjTt6hqbVU7I1sacEv/s=
+github.com/CalcMark/go-calcmark/v2 v2.0.0 h1:u4Lwckt0BftOuFFc43Wo5UMr6mH4f0ANOOSlWtH9jsQ=
+github.com/CalcMark/go-calcmark/v2 v2.0.0/go.mod h1:phmoVSpMuYvPsW8eAiPLRHdBjTt6hqbVU7I1sacEv/s=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/handler.go
+++ b/handler.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/CalcMark/go-calcmark"
+	"github.com/CalcMark/go-calcmark/v2"
 )
 
 const maxBodySize = 1 << 20 // 1MB

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func calcmarkVersion() string {
 		return "dev"
 	}
 	for _, dep := range info.Deps {
-		if dep.Path == "github.com/CalcMark/go-calcmark" {
+		if dep.Path == "github.com/CalcMark/go-calcmark/v2" {
 			return dep.Version
 		}
 	}


### PR DESCRIPTION
## Summary

Bumps the lark to upstream `github.com/CalcMark/go-calcmark/v2 v2.0.0-rc.1`. The lark only consumes a tiny API surface (`calcmark.Convert` + `Options` + format constants), so the bump is mechanical: drop the local-development replace, switch to the released module, sweep import paths to add `/v2`.

This PR is intentionally **kept open during the v2.0 soak window** — it's the integration check that the lark plays cleanly with the new go-calcmark major. Merge once upstream tags `v2.0.0` stable.

## Verification

The trial leg of the work caught a real bug already: 3 of go-calcmark's 21 [shipped doc examples](https://github.com/CalcMark/go-calcmark/tree/main/testdata/examples) failed under v2 because of the v1→v2 contract change on `grow`/`compound`/`depreciate` (3-arg form requires a plain Number, not a Duration). Those were [fixed upstream in commit `3125c41`](https://github.com/CalcMark/go-calcmark/commit/3125c41) before rc.1 was tagged.

Post-fix: all 21 examples render cleanly under v2.0.0-rc.1 via `calcmark.Convert`. The lark's own tests stay green.

| Gate | Status |
|---|---|
| `go build ./...` | ✓ clean |
| `go test ./...` | ✓ green |
| All 21 upstream examples through `calcmark.Convert` | ✓ pass |
| API surface (`calcmark.Convert`, `Options`, format constants) | ✓ unchanged |

## Changes

- `go.mod`: drop local replace, switch require to `github.com/CalcMark/go-calcmark/v2 v2.0.0-rc.1`
- `handler.go` + `main.go`: import sweep `github.com/CalcMark/go-calcmark` → `github.com/CalcMark/go-calcmark/v2`

## After v2.0.0 stable

When upstream tags `v2.0.0`:
1. Single-line bump: `v2.0.0-rc.1` → `v2.0.0`
2. `go mod tidy`
3. Merge this PR

If soak surfaces issues that need an `rc.2`, this PR follows along: bump to `v2.0.0-rc.2` and keep soaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)